### PR TITLE
fixes JENKINS-21080

### DIFF
--- a/src/main/resources/jp/ikedam/jenkins/plugins/jobcopy_builder/CopiedjobinfoAction/summary.jelly
+++ b/src/main/resources/jp/ikedam/jenkins/plugins/jobcopy_builder/CopiedjobinfoAction/summary.jelly
@@ -28,10 +28,10 @@ THE SOFTWARE.
     <t:summary icon="package.png">
         <l:pane title="${%Copied Job}" width="3">
             <f:entry title="${%Copied From}">
-                <a href="${baseURL}/${it.fromUrl}">${it.fromJobName}</a>
+                <a href="${rootURL}/${it.fromUrl}">${it.fromJobName}</a>
             </f:entry>
             <f:entry title="${%Copied To}">
-                <a href="${baseURL}/${it.toUrl}">${it.toJobName}</a>
+                <a href="${rootURL}/${it.toUrl}">${it.toJobName}</a>
             </f:entry>
         </l:pane>
         <j:if test="${it.failed}">


### PR DESCRIPTION
Here a change for JENKINS-21080 to create the correct link for the "Copied To" and "Copied From" fields
