### PR TITLE
Fix maven-findbugs-plugin issue

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,6 +85,21 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+  <dependencyManagement>
+    <!-- To resolve RequireUpperBoundDeps errors -->
+    <dependencies>
+      <dependency>
+        <groupId>commons-io</groupId>
+        <artifactId>commons-io</artifactId>
+        <version>2.2</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.ant</groupId>
+        <artifactId>ant</artifactId>
+        <version>1.9.2</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
   
   <build>
     <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>2.9</version>
+    <version>2.37</version>
   </parent>
 
   <groupId>jp.ikedam.jenkins.plugins</groupId>


### PR DESCRIPTION
CI fails with
```
[ERROR] Failed to execute goal org.codehaus.mojo:findbugs-maven-plugin:3.0.3:findbugs (findbugs) on project jobcopy-builder: Unable to parse configuration of mojo org.codehaus.mojo:findbugs-maven-plugin:3.0.3:findbugs for parameter pluginArtifacts: Cannot assign configuration entry 'pluginArtifacts' with value '${plugin.artifacts}' of type java.util.Collections.UnmodifiableRandomAccessList to property of type java.util.ArrayList -> [Help 1]
org.apache.maven.lifecycle.LifecycleExecutionException: Failed to execute goal org.codehaus.mojo:findbugs-maven-plugin:3.0.3:findbugs (findbugs) on project jobcopy-builder: Unable to parse configuration of mojo org.codehaus.mojo:findbugs-maven-plugin:3.0.3:findbugs for parameter pluginArtifacts: Cannot assign configuration entry 'pluginArtifacts' with value '${plugin.artifacts}' of type java.util.Collections.UnmodifiableRandomAccessList to property of type java.util.ArrayList
```

This happens when using old maven-findbugs-plugin and maven-3.6.
