### PR TITLE
[JENKINS-64160] Remove junit from the dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,6 +50,7 @@
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <version>4.13.1</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>


### PR DESCRIPTION
https://issues.jenkins-ci.org/browse/JENKINS-64160

The dependency to junit was introduced here: 8951272022b4601b5133a6229360431513e02ce8.
Apparently, it's only for testing purpose.
